### PR TITLE
Update for AKI 3.8.0 release-29197

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+src/CactusPie.ContainerQuickLoot/References
 # User-specific files
 *.rsuser
 *.suo

--- a/src/CactusPie.ContainerQuickLoot/CactusPie.ContainerQuickLoot.csproj
+++ b/src/CactusPie.ContainerQuickLoot/CactusPie.ContainerQuickLoot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.4.2</Version>
     <Authors>CactusPie</Authors>
   </PropertyGroup>
 

--- a/src/CactusPie.ContainerQuickLoot/ContainerQuickLootPlugin.cs
+++ b/src/CactusPie.ContainerQuickLoot/ContainerQuickLootPlugin.cs
@@ -4,7 +4,7 @@ using JetBrains.Annotations;
 
 namespace CactusPie.ContainerQuickLoot
 {
-    [BepInPlugin("com.cactuspie.containerquikloot", "CactusPie.ContainerQuickLoot", "1.4.1")]
+    [BepInPlugin("com.cactuspie.containerquikloot", "CactusPie.ContainerQuickLoot", "1.4.2")]
     public class ContainerQuickLootPlugin : BaseUnityPlugin
     {
         internal static ConfigEntry<bool> EnableForCtrlClick { get; set; }


### PR DESCRIPTION
**Merge stacks for non-loot containers function still having issues [*see comments*](https://hub.sp-tarkov.com/files/file/1633-transfer-loot-into-a-container-automatically/#comments/comment35011),sorry I can't fix it**
### Update for AKI 3.8.0 release-29197
- update mod version to 1.4.2

- update gitignore files

- fix mod can work in hideout (line:135),now only work in raid

- update QuickTransferPatch.cs
--GClass2585 → InteractionsHandlerClass
--GStruct375<GInterface275> → GStruct414<GInterface324> 
--IContainer → EFT.InventoryLogic.IContainer
--GClass2318 → StashGridClass
--GStruct375<GClass2599> → GStruct414<GClass2788>
--GClass2580 → GClass2769
--GStruct375<GClass2597> → GStruct414<GClass2786>
--Player.Inventory could be public